### PR TITLE
Data in transit encryption with TLS in Mysqli/PDO Mysql drivers

### DIFF
--- a/Tests/Mock/Driver.php
+++ b/Tests/Mock/Driver.php
@@ -48,6 +48,7 @@ class Driver
 			'getAffectedRows',
 			'getCollation',
 			'getConnectionCollation',
+			'getConnectionEncryption',
 			'getConnectors',
 			'getDateFormat',
 			'getInstance',

--- a/Tests/Stubs/nosqldriver.php
+++ b/Tests/Stubs/nosqldriver.php
@@ -215,6 +215,19 @@ class NosqlDriver extends DatabaseDriver
 	}
 
 	/**
+	 * Method to get the database encryption details (cipher and protocol) in use.
+	 *
+	 * @return  string  The database encryption details.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException
+	 */
+	public function getConnectionEncryption(): string
+	{
+		return '';
+	}
+
+	/**
 	 * Get the number of returned rows for the previous executed SQL statement.
 	 *
 	 * @param   resource  $cursor  An optional database cursor resource to extract the row count from.

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -141,6 +141,15 @@ interface DatabaseInterface
 	public function getConnectionCollation();
 
 	/**
+	 * Method to get the database encryption details (cipher and protocol) in use.
+	 *
+	 * @return  string  The database encryption details.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getConnectionEncryption(): string;
+
+	/**
 	 * Get the total number of SQL statements executed by the database driver.
 	 *
 	 * @return  integer

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -117,18 +117,6 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 		$options['driver']   = 'mysql';
 		$options['charset']  = $options['charset'] ?? 'utf8';
 		$options['sqlModes'] = isset($options['sqlModes']) ? (array) $options['sqlModes'] : $sqlModes;
-		$options['ssl']      = isset($options['ssl']) ? $options['ssl'] : [];
-
-		if ($options['ssl'] !== [])
-		{
-			$options['ssl']['enable']             = isset($options['ssl']['enable']) ? $options['ssl']['enable'] : false;
-			$options['ssl']['cipher']             = isset($options['ssl']['cipher']) ? $options['ssl']['cipher'] : null;
-			$options['ssl']['ca']                 = isset($options['ssl']['ca']) ? $options['ssl']['ca'] : null;
-			$options['ssl']['capath']             = isset($options['ssl']['capath']) ? $options['ssl']['capath'] : null;
-			$options['ssl']['key']                = isset($options['ssl']['key']) ? $options['ssl']['key'] : null;
-			$options['ssl']['cert']               = isset($options['ssl']['cert']) ? $options['ssl']['cert'] : null;
-			$options['ssl']['verify_server_cert'] = isset($options['ssl']['verify_server_cert']) ? $options['ssl']['verify_server_cert'] : null;
-		}
 
 		$this->charset = $options['charset'];
 

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -176,7 +176,7 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 			// PDO, if no cipher, ca, capath, cert and key are set, can't start TLS one-way connection, set a common ciphers suit to force it.
 			if ($sslContextIsNull === true)
 			{
-				$this->options['driverOptions'][\PDO::MYSQL_ATTR_SSL_CIPHER] = implode(':', static::defaultCipherSuit);
+				$this->options['driverOptions'][\PDO::MYSQL_ATTR_SSL_CIPHER] = implode(':', static::$defaultCipherSuit);
 			}
 
 			// If costumized, for capable systems (PHP 7.0.14+ and 7.1.4+) verify certificate chain and Common Name to driver options.

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -163,12 +163,13 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 			if ($tlsContextIsNull === true)
 			{
 				$this->options['driverOptions'][\PDO::MYSQL_ATTR_SSL_CIPHER] = implode(':', [
-					'AES128-GCM-SHA256',
-					'AES256-GCM-SHA384',
-					'AES128-CBC-SHA256',
-					'AES256-CBC-SHA384',
-					'DES-CBC3-SHA',
-				]);
+						'AES128-GCM-SHA256',
+						'AES256-GCM-SHA384',
+						'AES128-CBC-SHA256',
+						'AES256-CBC-SHA384',
+						'DES-CBC3-SHA',
+					]
+				);
 			}
 
 			// If costumized, for capable systems (PHP 7.0.14+ and 7.1.4+) verify certificate chain and Common Name to driver options.

--- a/src/Mysql/MysqlDriver.php
+++ b/src/Mysql/MysqlDriver.php
@@ -176,7 +176,7 @@ class MysqlDriver extends PdoDriver implements UTF8MB4SupportInterface
 			// PDO, if no cipher, ca, capath, cert and key are set, can't start TLS one-way connection, set a common ciphers suit to force it.
 			if ($sslContextIsNull === true)
 			{
-				$this->options['driverOptions'][\PDO::MYSQL_ATTR_SSL_CIPHER] = implode(':', $this->defaultCipherSuit);
+				$this->options['driverOptions'][\PDO::MYSQL_ATTR_SSL_CIPHER] = implode(':', static::defaultCipherSuit);
 			}
 
 			// If costumized, for capable systems (PHP 7.0.14+ and 7.1.4+) verify certificate chain and Common Name to driver options.

--- a/src/Mysqli/MysqliDriver.php
+++ b/src/Mysqli/MysqliDriver.php
@@ -473,7 +473,8 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 	{
 		$this->connect();
 
-		$variables = $this->setQuery('SHOW SESSION STATUS WHERE `Variable_name` IN (\'Ssl_version\', \'Ssl_cipher\')')->loadObjectList('Variable_name');
+		$variables = $this->setQuery('SHOW SESSION STATUS WHERE `Variable_name` IN (\'Ssl_version\', \'Ssl_cipher\')')
+			->loadObjectList('Variable_name');
 
 		if (!empty($variables['Ssl_cipher']->Value))
 		{

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -78,6 +78,18 @@ abstract class PdoDriver extends DatabaseDriver
 		$options['port']          = isset($options['port']) ? (int) $options['port'] : null;
 		$options['password']      = $options['password'] ?? '';
 		$options['driverOptions'] = $options['driverOptions'] ?? [];
+		$options['ssl']           = isset($options['ssl']) ? $options['ssl'] : [];
+
+		if ($options['ssl'] !== [])
+		{
+			$options['ssl']['enable']             = isset($options['ssl']['enable']) ? $options['ssl']['enable'] : false;
+			$options['ssl']['cipher']             = isset($options['ssl']['cipher']) ? $options['ssl']['cipher'] : null;
+			$options['ssl']['ca']                 = isset($options['ssl']['ca']) ? $options['ssl']['ca'] : null;
+			$options['ssl']['capath']             = isset($options['ssl']['capath']) ? $options['ssl']['capath'] : null;
+			$options['ssl']['key']                = isset($options['ssl']['key']) ? $options['ssl']['key'] : null;
+			$options['ssl']['cert']               = isset($options['ssl']['cert']) ? $options['ssl']['cert'] : null;
+			$options['ssl']['verify_server_cert'] = isset($options['ssl']['verify_server_cert']) ? $options['ssl']['verify_server_cert'] : null;
+		}
 
 		// Finalize initialisation
 		parent::__construct($options);

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -265,6 +265,29 @@ abstract class PdoDriver extends DatabaseDriver
 				$replace = ['#HOST#', '#PORT#', '#DBNAME#'];
 				$with    = [$this->options['host'], $this->options['port'], $this->options['database']];
 
+				// For data in transit TLS encryption.
+				if ($this->options['ssl'] !== [] && $this->options['ssl']['enable'] === true)
+				{
+					$format .= ';sslmode=' . (isset($this->options['ssl']['verify_server_cert']) && $this->options['ssl']['verify_server_cert'] === true ? 'verify-full' : 'required');
+
+					$sslKeysMapping = [
+						'cipher' => null,
+						'ca'     => 'sslrootcert',
+						'capath' => null,
+						'key'    => 'sslkey',
+						'cert'   => 'sslcert',
+					];
+
+					// If costumized, add ciphersuit, ca file path, ca path, private key file path and certificate file path to PDO driver options.
+					foreach (['cipher', 'ca', 'capath', 'key', 'cert'] as $key => $value)
+					{
+						if ($sslKeysMapping[$key] !== null && $this->options['ssl'][$value] !== null)
+						{
+							$format .= ';' . $sslKeysMapping[$key] . '=' . $this->options['ssl'][$value];
+						}
+					}
+				}
+
 				break;
 
 			case 'sqlite':

--- a/src/Pdo/PdoDriver.php
+++ b/src/Pdo/PdoDriver.php
@@ -268,7 +268,14 @@ abstract class PdoDriver extends DatabaseDriver
 				// For data in transit TLS encryption.
 				if ($this->options['ssl'] !== [] && $this->options['ssl']['enable'] === true)
 				{
-					$format .= ';sslmode=' . (isset($this->options['ssl']['verify_server_cert']) && $this->options['ssl']['verify_server_cert'] === true ? 'verify-full' : 'required');
+					if (isset($this->options['ssl']['verify_server_cert']) && $this->options['ssl']['verify_server_cert'] === true)
+					{
+						$format .= ';sslmode=verify-full';
+					}
+					else
+					{
+						$format .= ';sslmode=required';
+					}
 
 					$sslKeysMapping = [
 						'cipher' => null,

--- a/src/Pgsql/PgsqlDriver.php
+++ b/src/Pgsql/PgsqlDriver.php
@@ -134,6 +134,20 @@ class PgsqlDriver extends PdoDriver
 	}
 
 	/**
+	 * Method to get the database encryption details (cipher and protocol) in use.
+	 *
+	 * @return  string  The database encryption details.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException
+	 */
+	public function getConnectionEncryption(): string
+	{
+		// TODO: Not fake this
+		return '';
+	}
+
+	/**
 	 * Shows the table CREATE statement that creates the given tables.
 	 *
 	 * This is unsuported by PostgreSQL.

--- a/src/Pgsql/PgsqlDriver.php
+++ b/src/Pgsql/PgsqlDriver.php
@@ -143,7 +143,18 @@ class PgsqlDriver extends PdoDriver
 	 */
 	public function getConnectionEncryption(): string
 	{
-		// TODO: Not fake this
+		$query = $this->getQuery(true)
+			->select($this->quoteName(['version', 'cipher']))
+			->from($this->quoteName('pg_stat_ssl'))
+			->where($this->quoteName('pid') . ' = pg_backend_pid()');
+
+		$variables = $this->setQuery($query)->loadAssoc();
+
+		if (!empty($variables['cipher']))
+		{
+			return $variables['version'] . ' (' . $variables['cipher'] . ')';
+		}
+
 		return '';
 	}
 

--- a/src/Sqlite/SqliteDriver.php
+++ b/src/Sqlite/SqliteDriver.php
@@ -169,6 +169,20 @@ class SqliteDriver extends PdoDriver
 	}
 
 	/**
+	 * Method to get the database encryption details (cipher and protocol) in use.
+	 *
+	 * @return  string  The database encryption details.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException
+	 */
+	public function getConnectionEncryption(): string
+	{
+		// TODO: Not fake this
+		return '';
+	}
+
+	/**
 	 * Shows the table CREATE statement that creates the given tables.
 	 *
 	 * Note: Doesn't appear to have support in SQLite

--- a/src/Sqlsrv/SqlsrvDriver.php
+++ b/src/Sqlsrv/SqlsrvDriver.php
@@ -355,6 +355,20 @@ class SqlsrvDriver extends DatabaseDriver
 	}
 
 	/**
+	 * Method to get the database encryption details (cipher and protocol) in use.
+	 *
+	 * @return  string  The database encryption details.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \RuntimeException
+	 */
+	public function getConnectionEncryption(): string
+	{
+		// TODO: Not fake this
+		return '';
+	}
+
+	/**
 	 * Retrieves field information about the given tables.
 	 *
 	 * @param   mixed    $table     A table name


### PR DESCRIPTION
### Summary of Changes

Add option to enable *data in transit* encryption with TLS in Mysqli/PDO Mysql drivers.

### Testing Instructions

0. Code review (not sure i miss something)
1. Test database connection (Mysqli and PDO Mysql) in business as usual mode , make sure it work
2. Prepare MariaDB/MySQL to accept SSL connections
2.1. Add in my.cnf (replace for instance, with your public https certificates/private key)

```ini
; [...] mysql/mariadb configuration options

[mysqld]
; [...] more mysql/mariadb server configuration options
ssl        = 1
ssl_cert   = /etc/pki/tls/certs/fullchain.cer ; certificate + intermediates
ssl_ca     = /etc/pki/tls/certs/ca-bundle.crt
ssl_key    = /etc/pki/tls/private/yourdomain.key
ssl_cipher = kECDHE+aECDSA+AESGCM+AES128:kECDHE+aECDSA+AESGCM+AES256:kECDHE+aECDSA+AES128+SHA:kECDHE+aECDSA+AES256+SHA:kDHE+aECDSA+AES128:kDHE+aECDSA+AES256:kECDHE+aRSA+AESGCM+AES128:kECDHE+aRSA+AESGCM+AES256:kECDHE+aRSA+AES128+SHA:kECDHE+aRSA+AES256+SHA:kDHE+aRSA+AESGCM+AES128:kDHE+aRSA+AESGCM+AES256:kDHE+aRSA+AES128:kDHE+aRSA+AES256:kRSA+aRSA+AESGCM+AES128:kRSA+aRSA+AESGCM+AES256:kRSA+aRSA+AES128+SHA:kRSA+aRSA+AES256+SHA
```

3. For each one of the drivers (Mysqli and PDO Mysql):
3.1. Test database connection enabling TLS and no certificate verfication, make sure it work (read the notes below)
```php
$options['ssl'] = ['enable' => true, 'verify_server_cert' => false];
```
3.2. Test database connection enabling TLS and certificate verfication, make sure it work (read the notes below)
```php
$options['ssl'] = ['enable' => true, 'verify_server_cert' => true];
```
3.3 Make more tests with ca, cipher, key, etc , example:
```php
$options['ssl'] = [
  'enable' => true,
  'verify_server_cert' => true,
  'cipher'   => 'AES256-GCM-SHA384:DES-CBC3-SHA'
];
```
 Note: with client cert and key you can test two-way encryption also

### Documentation Changes Required

Would be nice to have a tutorial.

### Notes

- Only tested in Joomla 4.0 staging | CentOS 7.x | MariaDB 10.4.x (mariadb repository) | PHP 7.3.x (ius repository)
- IMPORTANT: the server certificate verification verifies the certificate Common Name (CN) so you have to have the same host in the database connection as the common name of the certificate.
 So for instance, if your host certificate Common Name is `yourdomain.tld` make sure you can conneect to your database using `yourdomain.tld` hostname.
 Server Name Indication (SNI) is not allowed, so no Subject Alternate Names (SAN) are processed
 To solve this i added this in `/etc/hosts`, allowed mariadb/mysql user to connect with that domain and used `yourdomain.tld` as database host:
```ini
127.0.0.1 yourdomain.tld
```
- TLS only makes sense in TCP connections, not in unix sockets so make use you are using a TCP connection (ex: 127.0.0.1:3306 | `yourdomain.tld`:3306) or you will have an error when enabling TLS
- To make sure you have an encrypted connection use the new method in both drivers (it should return the TLS protocol and cipher used in the connection)
 ```php
echo $db->getConnectionEncryption();
```

### Reference

- https://mariadb.com/kb/en/library/data-in-transit-encryption/
- https://mariadb.com/kb/en/library/securing-connections-for-client-and-server/

### Future WishList

- Someone to look at postrgreSQL TLS connections
- Someone to make test for this
- Improvements in databases systems to allow SNI and better ciphers
- PHP be more consistent across database drivers ...
